### PR TITLE
Fix issue when initial location redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "mocha": "^2.3.4",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
+    "react-redux": "^4.4.0",
     "react-router": "^2.0.0",
     "redux": "^3.0.4",
     "redux-devtools": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.4",
     "react": "^0.14.3",
+    "react-dom": "^0.14.3",
+    "react-router": "^2.0.0",
     "redux": "^3.0.4",
     "redux-devtools": "^3.0.0",
     "redux-devtools-dock-monitor": "^1.0.1",

--- a/src/sync.js
+++ b/src/sync.js
@@ -101,8 +101,6 @@ export default function syncHistoryWithStore(history, store, {
     listen(listener) {
       // Copy of last location.
       let lastPublishedLocation = getLocationInStore(true)
-      // History listeners expect a synchronous call
-      listener(lastPublishedLocation)
 
       // Keep track of whether we unsubscribed, as Redux store
       // only applies changes in subscriptions on next dispatch
@@ -117,6 +115,11 @@ export default function syncHistoryWithStore(history, store, {
           listener(lastPublishedLocation)
         }
       })
+
+      // History listeners expect a synchronous call. Make the first call to the
+      // listener after subscribing to the store, in case the listener causes a
+      // location change (e.g. when it redirects)
+      listener(lastPublishedLocation)
 
       // Let user unsubscribe later
       return () => {


### PR DESCRIPTION
We've been using the cutting edge version in a new project, and all work that went into v4 is much appreciated!

Today we found a bug: if the initial route redirects to another location, then the `Router` component doesn't update properly and leaves the user with an empty page. It's common to use `onEnter` on a `Route` to redirect the user to a login page when she is not logged. The `syncs history -> components when the initial route gets replaced` test in this PR replicates the problem.

The problem lies in the `syncHistoryWithStore`'s custom listening logic. It makes the first synchronous call to each listener before it subscribes to the store changes, so if the listener causes a location change and thus a store change (e.g. when a location redirects), then the listener is not notified of that change. This PR fixes the problem by subscribing to the store before making the first call to the listener.

Hopefully this bug can be fixed before the final v4 is released!