### PR TITLE
Fix `LOCATION_CHANGE` action on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,6 @@ These action creators are also available in one single object as `routerActions`
 
 A middleware you can apply to your Redux `store` to capture dispatched actions created by the action creators. It will redirect those actions to the provided `history` instance.
 
-#### `LOCATION_CHANGE`
+#### `@@router/LOCATION_CHANGE`
 
 An action type that you can listen for in your reducers to be notified of route updates. Fires *after* any changes to history.


### PR DESCRIPTION
The correct action is `@@router/LOCATION_CHANGE`: https://github.com/reactjs/react-router-redux/blob/master/src/reducer.js#L5

=)