### PR TITLE
Document: improve "LOCATION_CHANGE action type"

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,4 +180,6 @@ A middleware you can apply to your Redux `store` to capture dispatched actions c
 
 An action type that you can listen for in your reducers to be notified of route updates. Fires *after* any changes to history.
 
-Notice: it(`LOCATION_CHANGE`) changed names since 3.0.0 version, so if you want use it and your dependencies under 3.0.0 version, you should upgrade this lib by `npm upgrade`
+Notice1: it(`LOCATION_CHANGE`) changed names since 3.0.0 version, so if you want use it and your dependencies under 3.0.0 version, you should upgrade this lib by `npm upgrade`
+
+Notice2: if you upgrade this lib by `npm upgrade`, you need change some code for new  version's api 

--- a/README.md
+++ b/README.md
@@ -179,3 +179,5 @@ A middleware you can apply to your Redux `store` to capture dispatched actions c
 #### `LOCATION_CHANGE`
 
 An action type that you can listen for in your reducers to be notified of route updates. Fires *after* any changes to history.
+
+Notice: it(LOCATION_CHANGE) changed names since 3.0.0, so if you want use it and  your dependencies under 3.0.0 , you should upgrade this lib by `npm upgrade`

--- a/README.md
+++ b/README.md
@@ -180,4 +180,4 @@ A middleware you can apply to your Redux `store` to capture dispatched actions c
 
 An action type that you can listen for in your reducers to be notified of route updates. Fires *after* any changes to history.
 
-Notice: it(LOCATION_CHANGE) changed names since 3.0.0, so if you want use it and  your dependencies under 3.0.0 , you should upgrade this lib by `npm upgrade`
+Notice: it(`LOCATION_CHANGE`) changed names since 3.0.0 version, so if you want use it and your dependencies under 3.0.0 version, you should upgrade this lib by `npm upgrade`


### PR DESCRIPTION
Oh I see it has something can be improved in doc. Because it(LOCATION_CHANGE) changed names since 3.0.0（in this year）, so doc should  show it.