### PR TITLE
Init currentLocation to initial location from the store

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -31,7 +31,6 @@ export default function syncHistoryWithStore(history, store, {
   }
 
   let initialLocation
-  let currentLocation
   let isTimeTraveling
   let unsubscribeFromStore
   let unsubscribeFromHistory
@@ -42,6 +41,9 @@ export default function syncHistoryWithStore(history, store, {
     return locationState.locationBeforeTransitions ||
       (useInitialIfEmpty ? initialLocation : undefined)
   }
+
+  // Init currentLocation with potential location in store
+  let currentLocation = getLocationInStore()
 
   // If the store is replayed, update the URL in the browser to match.
   if (adjustUrlOnReplay) {

--- a/test/_createSyncTest.js
+++ b/test/_createSyncTest.js
@@ -163,6 +163,33 @@ export default function createTests(createHistory, name, reset = defaultReset) {
       })
     })
 
+    describe('Server', () => {
+      it('handles inital load correctly', () => {
+        // Server
+        const { store: serverStore } = createSyncedHistoryAndStore(createHistory('/'))
+        expect(serverStore).toContainLocation({
+          pathname: '/',
+          action: 'POP'
+        })
+
+        // Client
+        let clientStore = createStore(combineReducers({
+          routing: routerReducer
+        }), serverStore.getState())
+        let clientHistory = useRouterHistory(createHistory)()
+
+        const historyListen = expect.createSpy()
+        const historyUnsubscribe = clientHistory.listen(historyListen)
+
+        syncHistoryWithStore(clientHistory, clientStore)
+
+        // We expect that we get a single call to history
+        expect(historyListen.calls.length).toBe(1)
+
+        historyUnsubscribe()
+      })
+    })
+
     describe('Redux DevTools', () => {
       let originalHistory, history, store, devToolsStore
 


### PR DESCRIPTION
This solves the problem when the server has initialised the state and the user already has things in their history.

Without this change a superfluous action will be pushed with the same URL that the user is already looking at resulting in that we would need to use the back button twice.

Resolves #313