### PR TITLE
Fix current location being set unnecessaily with server side rendering

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -74,9 +74,6 @@ export default function syncHistoryWithStore(history, store, {
       return
     }
 
-    // Remember where we are
-    currentLocation = location
-
     // Are we being called for the first time?
     if (!initialLocation) {
       // Remember as a fallback in case state is reset
@@ -87,6 +84,9 @@ export default function syncHistoryWithStore(history, store, {
         return
       }
     }
+
+    // Remember where we are
+    currentLocation = location
 
     // Tell the store to update by dispatching an action
     store.dispatch({

--- a/test/_createSyncTest.js
+++ b/test/_createSyncTest.js
@@ -164,7 +164,7 @@ export default function createTests(createHistory, name, reset = defaultReset) {
     })
 
     describe('Server', () => {
-      it('handles inital load correctly', () => {
+      it('handles initial load correctly', () => {
         // Server
         const { store: serverStore } = createSyncedHistoryAndStore(createHistory('/'))
         expect(serverStore).toContainLocation({
@@ -184,6 +184,13 @@ export default function createTests(createHistory, name, reset = defaultReset) {
         syncHistoryWithStore(clientHistory, clientStore)
 
         // We expect that we get a single call to history
+        expect(historyListen.calls.length).toBe(1)
+
+        clientStore.dispatch({
+          type: 'non-router'
+        })
+
+        // We expect that we still get only a single call to history after a non-router action is dispatched
         expect(historyListen.calls.length).toBe(1)
 
         historyUnsubscribe()


### PR DESCRIPTION
Fixes #410 

It seems like the `currentLocation` is always set when location change. However, this is unnecessary on server side rendering when location is already present in the store. Although both location are logically the same, they are actually different objects.

@dlmr Do double check if this PR works for your project. 

On side note, I think this bug might be present even before `4.0.5` but might not have encountered for other reasons.