### PR TITLE
Readme: Update rackt references to point to /reactjs/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ These two hooks will allow you to store the state that this library uses in what
 
 #### How do I access router state in a container component?
 
-React Router [provides route information via a route component's props](https://github.com/reactjs/react-router/blob/latest/docs/Introduction.md#getting-url-parameters). This makes it easy to access them from a container component. When using [react-redux](https://github.com/rackt/react-redux) to `connect()` your components to state, you can access the router's props from the [2nd argument of `mapStateToProps`](https://github.com/rackt/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options):
+React Router [provides route information via a route component's props](https://github.com/reactjs/react-router/blob/latest/docs/Introduction.md#getting-url-parameters). This makes it easy to access them from a container component. When using [react-redux](https://github.com/reactjs/react-redux) to `connect()` your components to state, you can access the router's props from the [2nd argument of `mapStateToProps`](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options):
 
 ```js
 function mapStateToProps(state, ownProps) {


### PR DESCRIPTION
Hi All 👋

Just a tiny one here!

I noticed a bad link in another project, linking to github.com/rackt/redux which is now held by somebody else it seems - who also has a redux repo, just to confuse things.

I opened a PR in that project but thought I'd have a quick look at other occurrences and noticed that there are a few vestiges here & updated them.

Ta 😀