### PR TITLE
Support v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 coverage
 *.log
+.idea

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ But the two libraries don't coordinate. You want to do time travel with your app
 
 This library helps you keep that bit of state in sync with your Redux store. We keep a copy of the current location hidden in state. When you rewind your application state with a tool like [Redux DevTools](https://github.com/gaearon/redux-devtools), that state change is propagated to React Router so it can adjust the component tree accordingly. You can jump around in state, rewinding, replaying, and resetting as much as you'd like, and this library will ensure the two stay in sync at all times.
 
+:warning: It is also possible to support old codebase which relied on the nested query parameter of history (removed from history > 4). Head to `query_support` for more information. 
+
 **This library is not _necessary_ for using Redux together with React Router. You can use the two together just fine without any additional libraries. It is useful if you care about recording, persisting, and replaying user actions, using time travel. If you don't care about these features, just [use Redux and React Router directly](http://stackoverflow.com/questions/36722584/how-to-sync-redux-state-and-url-hash-tag-params/36749963#36749963).**
 
 ## Installation
@@ -156,6 +158,7 @@ The `options` object takes in the following optional keys:
 
 - `selectLocationState` - (default `state => state.routing`) A selector function to obtain the history state from your store. Useful when not using the provided `routerReducer` to store history state. Allows you to use wrappers, such as Immutable.js.
 - `adjustUrlOnReplay` - (default `true`) When `false`, the URL will not be kept in sync during time travel. This is useful when using `persistState` from Redux DevTools and not wanting to maintain the URL state when restoring state.
+- `query_support` - (default `false`) When `true`, a query object is added to the store, it helps to support code that still rely on the query object from history < 4.
 
 #### `push(location)`, `replace(location)`, `go(number)`, `goBack()`, `goForward()`
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.4",
+    "query-string": "^4.3.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-redux": "^4.4.0",


### PR DESCRIPTION
Support react-router v4 with history v4.
Use new dependency query-string for supporting query parameter present in old version of react-router coupled with history (< v4).

A simple new `query_support` parameter is available, please check updated README.

This PR make react-router-redux compatible with react-router v4 and history v4 and migration easy.

Example of Rooting:

```javascript
import React from 'react';
import {Provider} from 'react-redux';
import {Router} from 'react-router';
import {syncHistoryWithStore} from 'react-router-redux';
import {createHashHistory} from 'history';

// routes conifg
import Routes from '../routes';

const Root = ({store}) => {
    const history = syncHistoryWithStore(createHashHistory(), store, {query_support: true});

    return (<Provider {...{store}}>
                <Router history={history}>
                    <Routes/>
                </Router>
    </Provider>);
};
```

Note `routerMiddleware` takes in parameter history, so it's better to put the declaration of your history in a file and import it for passing it to `syncHistoryWithStore` and `routerMiddleware` ;)