### PR TITLE
Prevent undefined action crash

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -7,6 +7,7 @@ import { CALL_HISTORY_METHOD } from './actions'
  */
 export default function routerMiddleware(history) {
   return () => next => action => {
+    if (!action) return next()
     if (action.type !== CALL_HISTORY_METHOD) {
       return next(action)
     }


### PR DESCRIPTION
I've done a little modification to prevent a undefined Exception. When you dont have signed action var in the middleware, the app crashes.